### PR TITLE
fix: bump log4j to a version where CVE-2021-44228 is fixed.

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -22,7 +22,7 @@ repositories {
 def asyncProfilerVersion = "2.0"
 dependencies {
     implementation files("$buildDir/async-profiler/async-profiler.jar")
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.14.1'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.16.0'
 
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.7.2'
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.7.2'


### PR DESCRIPTION
More details at
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228