### PR TITLE
feat: initial JFR format support.

### DIFF
--- a/agent/src/main/java/io/pyroscope/http/Format.java
+++ b/agent/src/main/java/io/pyroscope/http/Format.java
@@ -1,0 +1,15 @@
+package io.pyroscope.http;
+
+public enum Format {
+    COLLAPSED ("collapsed"),
+    JFR ("jfr");
+
+    /**
+     * Profile data format, as expected by Pyroscope's HTTP API.
+     */
+    public final String id;
+
+    Format(String id) {
+        this.id = id;
+    }
+}

--- a/agent/src/main/java/io/pyroscope/javaagent/Profiler.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/Profiler.java
@@ -1,12 +1,15 @@
 package io.pyroscope.javaagent;
 
+import io.pyroscope.http.Format;
 import one.profiler.AsyncProfiler;
 import one.profiler.Counter;
 import org.apache.logging.log4j.Logger;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.time.Duration;
 import java.time.Instant;
@@ -16,6 +19,7 @@ class Profiler {
     private final Logger logger;
     private final EventType eventType;
     private final Duration interval;
+    private final Format format;
 
     private static String libraryPath;
     static {
@@ -125,16 +129,22 @@ class Profiler {
 
     // TODO this is actually start of snapshot, not profiling as a whole
     private Instant profilingStarted = null;
+    private File tempFile;
 
-    Profiler(final Logger logger, final EventType eventType, final Duration interval) {
+    Profiler(final Logger logger, final EventType eventType, final Duration interval, final Format format) {
         this.logger = logger;
         this.eventType = eventType;
         this.interval = interval;
+        this.format = format;
     }
 
     // TODO new method for starting new snapshot/batch
     final synchronized void start() {
-        instance.start(eventType.id, interval.toNanos());
+        if (format == Format.JFR) {
+            startJFR();
+        } else {
+            instance.start(eventType.id, interval.toNanos());
+        }
         profilingStarted = Instant.now();
         logger.info("Profiling started");
     }
@@ -148,12 +158,45 @@ class Profiler {
             eventType,
             profilingStarted,
             Instant.now(),
-            instance.dumpCollapsed(Counter.SAMPLES)
+            format == Format.JFR ? dumpJFR() : instance.dumpCollapsed(Counter.SAMPLES).getBytes(StandardCharsets.UTF_8)
         );
 
         // TODO use `this.start()` or analogue
         profilingStarted = Instant.now();
-        instance.start(eventType.id, interval.toNanos());
+        if (format == Format.JFR) {
+            restartJFR();
+        } else {
+            instance.start(eventType.id, interval.toNanos());
+        }
         return result;
     }
+
+    final private void startJFR() {
+        try {
+            // flight recorder is built on top of a file descriptor, so we need a file.
+            tempFile = File.createTempFile("pyroscope", ".jfr");
+            tempFile.deleteOnExit();
+            instance.execute(String.format("start,event=%s,interval=%s,file=%s", eventType.id, interval.toNanos(), tempFile.toString()));
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    final private void restartJFR() {
+        try {
+            instance.execute(String.format("start,event=%s,interval=%s,file=%s", eventType.id, interval.toNanos(), tempFile.toString()));
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    final private byte[] dumpJFR() {
+        try {
+            instance.stop();
+            return new FileInputStream(tempFile).readAllBytes();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
 }

--- a/agent/src/main/java/io/pyroscope/javaagent/Profiler.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/Profiler.java
@@ -5,6 +5,7 @@ import one.profiler.AsyncProfiler;
 import one.profiler.Counter;
 import org.apache.logging.log4j.Logger;
 
+import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -193,7 +194,9 @@ class Profiler {
     final private byte[] dumpJFR() {
         try {
             instance.stop();
-            return new FileInputStream(tempFile).readAllBytes();
+            byte[] bytes = new byte[(int) tempFile.length()];
+            new DataInputStream(new FileInputStream(tempFile)).readFully(bytes);
+            return bytes;
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }

--- a/agent/src/main/java/io/pyroscope/javaagent/PyroscopeAgent.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/PyroscopeAgent.java
@@ -41,7 +41,7 @@ public class PyroscopeAgent {
         }
 
         try {
-            final Profiler profiler = new Profiler(logger, config.profilingEvent, config.profilingInterval);
+            final Profiler profiler = new Profiler(logger, config.profilingEvent, config.profilingInterval, config.format);
 
             final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
                     public Thread newThread(Runnable r) {

--- a/agent/src/main/java/io/pyroscope/javaagent/Snapshot.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/Snapshot.java
@@ -6,9 +6,9 @@ final class Snapshot {
     public final EventType eventType;
     public final Instant started;
     public final Instant finished;
-    public final String data;
+    public final byte[] data;
 
-    Snapshot(final EventType eventType, final Instant started, final Instant finished, final String data) {
+    Snapshot(final EventType eventType, final Instant started, final Instant finished, final byte[] data) {
         this.eventType = eventType;
         this.started = started;
         this.finished = finished;

--- a/agent/src/main/java/io/pyroscope/javaagent/config/Config.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/config/Config.java
@@ -1,5 +1,6 @@
 package io.pyroscope.javaagent.config;
 
+import io.pyroscope.http.Format;
 import io.pyroscope.javaagent.EventType;
 import io.pyroscope.javaagent.PreConfigLogger;
 import org.apache.logging.log4j.Level;
@@ -19,12 +20,14 @@ public final class Config {
     private static final String PYROSCOPE_SERVER_ADDRESS_CONFIG = "PYROSCOPE_SERVER_ADDRESS";
     private static final String PYROSCOPE_ADHOC_SERVER_ADDRESS_CONFIG = "PYROSCOPE_ADHOC_SERVER_ADDRESS";
     private static final String PYROSCOPE_AUTH_TOKEN_CONFIG = "PYROSCOPE_AUTH_TOKEN";
+    private static final String PYROSCOPE_FORMAT_CONFIG = "PYROSCOPE_FORMAT";
 
     private static final String DEFAULT_SPY_NAME = "javaspy";
     private static final Duration DEFAULT_PROFILING_INTERVAL = Duration.ofMillis(10);
     private static final EventType DEFAULT_PROFILER_EVENT = EventType.ITIMER;
     private static final Duration DEFAULT_UPLOAD_INTERVAL = Duration.ofSeconds(10);
     private static final String DEFAULT_SERVER_ADDRESS = "http://localhost:4040";
+    private static final Format DEFAULT_FORMAT = Format.COLLAPSED;
 
     public final String spyName = DEFAULT_SPY_NAME;
     public final String applicationName;
@@ -35,6 +38,7 @@ public final class Config {
     public final String serverAddress;
     public final String authToken;
     public final String timeseriesName;
+    public final Format format;
 
     Config(final String applicationName,
            final Duration profilingInterval,
@@ -42,7 +46,8 @@ public final class Config {
            final Duration uploadInterval,
            final Level logLevel,
            final String serverAddress,
-           final String authToken
+           final String authToken,
+           final Format format
         ) {
         this.applicationName = applicationName;
         this.profilingInterval = profilingInterval;
@@ -52,6 +57,7 @@ public final class Config {
         this.serverAddress = serverAddress;
         this.authToken = authToken;
         this.timeseriesName = timeseriesName(applicationName, profilingEvent);
+        this.format = format;
     }
 
     public long profilingIntervalInHertz() {
@@ -71,7 +77,8 @@ public final class Config {
             uploadInterval(),
             logLevel(),
             serverAddress(),
-            authToken()
+            authToken(),
+            format()
         );
     }
 
@@ -109,6 +116,8 @@ public final class Config {
     }
 
     private String timeseriesName(String applicationName, EventType eventType) {
+        if (format == Format.JFR)
+            return applicationName;
         return applicationName + "." + eventType.id;
     }
 
@@ -180,5 +189,20 @@ public final class Config {
 
     private static String authToken() {
         return System.getenv(PYROSCOPE_AUTH_TOKEN_CONFIG);
+    }
+
+    private static Format format() {
+        final String format = System.getenv(PYROSCOPE_FORMAT_CONFIG);
+        if (format == null || format.isEmpty())
+            return DEFAULT_FORMAT;
+        switch (format.trim().toLowerCase()) {
+            case "collapsed":
+                return Format.COLLAPSED;
+            case "jfr":
+                return Format.JFR;
+            default:
+                PreConfigLogger.LOGGER.warn("Unknown format {}, using {}", format, DEFAULT_FORMAT);
+                return DEFAULT_FORMAT;
+        }
     }
 }

--- a/agent/src/main/java/io/pyroscope/javaagent/config/Config.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/config/Config.java
@@ -56,7 +56,7 @@ public final class Config {
         this.logLevel = logLevel;
         this.serverAddress = serverAddress;
         this.authToken = authToken;
-        this.timeseriesName = timeseriesName(applicationName, profilingEvent);
+        this.timeseriesName = timeseriesName(applicationName, profilingEvent, format);
         this.format = format;
     }
 
@@ -115,7 +115,7 @@ public final class Config {
         }
     }
 
-    private String timeseriesName(String applicationName, EventType eventType) {
+    private String timeseriesName(String applicationName, EventType eventType, Format format) {
         if (format == Format.JFR)
             return applicationName;
         return applicationName + "." + eventType.id;


### PR DESCRIPTION
Java Flight Recorder format is a binary format integrated into Java and the only format in AsyncProfiler that supports multiple events concurrently.

In order to support multiple concurrent events in the Java integration, we have created a [JFR parser](https://github.com/pyroscope-io/jfr-parser/) and [integrated the parser](https://github.com/pyroscope-io/pyroscope/pull/954) in Pyroscope.

Now, we are adding support to generate the profiling data in this format in the agent. This is only a first iteration towards full, multi-event JFR ingestion support but we are not there yet.

This first step just supports defining the format through a new environment variable (PYROSCOPE_FORMAT). By default the old (collapsed) format will be used, but setting the variable to jfr:

```
PYROSCOPE_FORMAT=jfr
```

will use the new JFR format instead.

Note that this is only supported for CPU events (cpu, itimer, wall), the rest of events (alloc, locks) aren't currently support with this format (for now).