### PR TITLE
feat: add support for memory allocation events in JFR format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,26 +28,27 @@ On the startup, the agent deploys the native corresponding library into `/tmp/${
 
 The agent is configured using environment variables.
 
-### `PYROSCOPE_APPLICATION_NAME`
-The application name used when uploading profiling data. Generated if not provided.
+- `PYROSCOPE_APPLICATION_NAME`: The application name used when uploading profiling data. Generated if not provided.
+- `PYROSCOPE_PROFILING_INTERVAL`: Sets the profiling interval in nanoseconds or in other units, if N is followed by `ms` (for milliseconds), `us` (for microseconds), or `s` (for seconds). See [async-profiler documentation](https://github.com/jvm-profiling-tools/async-profiler) for details. The default is `10ms`.
+- `PYROSCOPE_UPLOAD_INTERVAL`: Sets the profiling interval for uploading snapshots. The default is `10s`.
+- `PYROSCOPE_PROFILER_EVENT`: Sets the profiling event. See [async-profiler documentation](https://github.com/jvm-profiling-tools/async-profiler) for details. The supported values are `cpu`, `alloc`, `lock`, `wall`, and `itimer`. The defaults is `itimer`.
+- `PYROSCOPE_LOG_LEVEL`: The log level: `debug`, `info`, `warn`, `error`. The default is `info`.
+- `PYROSCOPE_SERVER_ADDRESS`: The address of the Pyroscope server. The default is `http://localhost:4040`.
+- `PYROSCOPE_AUTH_TOKEN`: The authorization token used to upload profiling data.
 
-### `PYROSCOPE_PROFILING_INTERVAL`
-Sets the profiling interval in nanoseconds or in other units, if N is followed by `ms` (for milliseconds), `us` (for microseconds), or `s` (for seconds). See [async-profiler documentation](https://github.com/jvm-profiling-tools/async-profiler) for details. The default is `10ms`.
+### JFR format and multiple event support
 
-### `PYROSCOPE_UPLOAD_INTERVAL`
-Sets the profiling interval for uploading snapshots. The default is `10s`.
+Starting with version v0.5.0 JFR format is (partially) supported to be able to support multiple events (JFR is the only output format that supports [multiple events in `async-profiler`](https://github.com/jvm-profiling-tools/async-profiler#multiple-events)).
+It currently supports the following events:
+- jdk.ExecutionSample (supported in `pyroscope-java >= 0.5.0` and `pyroscope >= 0.13.0`), used for CPU sampling events (`itimer`, `cpu`, `wall`).
+- jdk.ObjectAllocationInNewTLAB (supported in `pyroscope-java >= 0.5.0` and `pyroscope >= 0.13.0`), used for alloc sampling.
+- jdk.ObjectAllocationOutsideTLAB (supported in `pyroscope-java >= 0.5.0` and `pyroscope >= 0.13.0`), used for alloc sampling.
 
-### `PYROSCOPE_PROFILER_EVENT`
-Sets the profiling event. See [async-profiler documentation](https://github.com/jvm-profiling-tools/async-profiler) for details. The supported values are `cpu`, `alloc`, `lock`, `wall`, and `itimer`. The defaults is `itimer`.
+There are several environment variables that define how multiple event configuration works:
 
-### `PYROSCOPE_LOG_LEVEL`
-The log level: `debug`, `info`, `warn`, `error`. The default is `info`.
-
-### `PYROSCOPE_SERVER_ADDRESS`
-The address of the Pyroscope server. The default is `http://localhost:4040`.
-
-### `PYROSCOPE_AUTH_TOKEN`
-The authorization token used to upload profiling data.
+- `PYROSCOPE_FORMAT` sets the profiler output format. The default is `collapsed`, but in order to support multiple formats it must be set to `jfr`.
+- `PYROSCOPE_PROFILER_EVENT` sets the profiler event. With JFR format enabled, this event refers to one of the possible CPU profiling events: `itimer`, `cpu`, `wall`. The default is `itimer`.
+- `PYROSCOPE_PROFILER_ALLOC` sets the allocation threshold to register the events, in bytes (equivalent to `--alloc=` in `async-profiler`. The default value is 0, which means that allocation profiling is disabled. Setting it to `1` will register all the events.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ The agent is configured using environment variables.
 Starting with version v0.5.0 JFR format is (partially) supported to be able to support multiple events (JFR is the only output format that supports [multiple events in `async-profiler`](https://github.com/jvm-profiling-tools/async-profiler#multiple-events)).
 It currently supports the following events:
 - jdk.ExecutionSample (supported in `pyroscope-java >= 0.5.0` and `pyroscope >= 0.13.0`), used for CPU sampling events (`itimer`, `cpu`, `wall`).
-- jdk.ObjectAllocationInNewTLAB (supported in `pyroscope-java >= 0.5.0` and `pyroscope >= 0.13.0`), used for alloc sampling.
-- jdk.ObjectAllocationOutsideTLAB (supported in `pyroscope-java >= 0.5.0` and `pyroscope >= 0.13.0`), used for alloc sampling.
+- jdk.ObjectAllocationInNewTLAB (supported in `pyroscope-java >= 0.5.0` and `pyroscope >= 0.14.0`), used for alloc sampling.
+- jdk.ObjectAllocationOutsideTLAB (supported in `pyroscope-java >= 0.5.0` and `pyroscope >= 0.14.0`), used for alloc sampling.
 
 There are several environment variables that define how multiple event configuration works:
 

--- a/agent/src/main/java/io/pyroscope/javaagent/Profiler.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/Profiler.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 class Profiler {
     private final Logger logger;
     private final EventType eventType;
+    private final String alloc;
     private final Duration interval;
     private final Format format;
 
@@ -132,8 +133,9 @@ class Profiler {
     private Instant profilingStarted = null;
     private File tempFile;
 
-    Profiler(final Logger logger, final EventType eventType, final Duration interval, final Format format) {
+    Profiler(final Logger logger, final EventType eventType, final String alloc, final Duration interval, final Format format) {
         this.logger = logger;
+        this.alloc = alloc;
         this.eventType = eventType;
         this.interval = interval;
         this.format = format;
@@ -177,7 +179,7 @@ class Profiler {
             // flight recorder is built on top of a file descriptor, so we need a file.
             tempFile = File.createTempFile("pyroscope", ".jfr");
             tempFile.deleteOnExit();
-            instance.execute(String.format("start,event=%s,interval=%s,file=%s", eventType.id, interval.toNanos(), tempFile.toString()));
+            instance.execute(String.format("start,event=%s,alloc=%s,interval=%s,file=%s", eventType.id, alloc, interval.toNanos(), tempFile.toString()));
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }
@@ -185,7 +187,7 @@ class Profiler {
 
     final private void restartJFR() {
         try {
-            instance.execute(String.format("start,event=%s,interval=%s,file=%s", eventType.id, interval.toNanos(), tempFile.toString()));
+            instance.execute(String.format("start,event=%s,alloc=%s,interval=%s,file=%s", eventType.id, alloc, interval.toNanos(), tempFile.toString()));
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }
@@ -201,5 +203,4 @@ class Profiler {
             throw new IllegalStateException(e);
         }
     }
-
 }

--- a/agent/src/main/java/io/pyroscope/javaagent/PyroscopeAgent.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/PyroscopeAgent.java
@@ -41,7 +41,12 @@ public class PyroscopeAgent {
         }
 
         try {
-            final Profiler profiler = new Profiler(logger, config.profilingEvent, config.profilingInterval, config.format);
+            final Profiler profiler = new Profiler(
+                    logger,
+                    config.profilingEvent,
+                    config.profilingAlloc,
+                    config.profilingInterval,
+                    config.format);
 
             final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
                     public Thread newThread(Runnable r) {

--- a/agent/src/main/java/io/pyroscope/javaagent/config/Config.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/config/Config.java
@@ -15,6 +15,7 @@ public final class Config {
     private static final String PYROSCOPE_APPLICATION_NAME_CONFIG = "PYROSCOPE_APPLICATION_NAME";
     private static final String PYROSCOPE_PROFILING_INTERVAL_CONFIG = "PYROSCOPE_PROFILING_INTERVAL";
     private static final String PYROSCOPE_PROFILER_EVENT_CONFIG = "PYROSCOPE_PROFILER_EVENT";
+    private static final String PYROSCOPE_PROFILER_ALLOC_CONFIG = "PYROSCOPE_PROFILER_ALLOC";
     private static final String PYROSCOPE_UPLOAD_INTERVAL_CONFIG = "PYROSCOPE_UPLOAD_INTERVAL";
     private static final String PYROSCOPE_LOG_LEVEL_CONFIG = "PYROSCOPE_LOG_LEVEL";
     private static final String PYROSCOPE_SERVER_ADDRESS_CONFIG = "PYROSCOPE_SERVER_ADDRESS";
@@ -25,6 +26,7 @@ public final class Config {
     private static final String DEFAULT_SPY_NAME = "javaspy";
     private static final Duration DEFAULT_PROFILING_INTERVAL = Duration.ofMillis(10);
     private static final EventType DEFAULT_PROFILER_EVENT = EventType.ITIMER;
+    private static final String DEFAULT_PROFILER_ALLOC = "0";
     private static final Duration DEFAULT_UPLOAD_INTERVAL = Duration.ofSeconds(10);
     private static final String DEFAULT_SERVER_ADDRESS = "http://localhost:4040";
     private static final Format DEFAULT_FORMAT = Format.COLLAPSED;
@@ -33,6 +35,7 @@ public final class Config {
     public final String applicationName;
     public final Duration profilingInterval;
     public final EventType profilingEvent;
+    public final String profilingAlloc;
     public final Duration uploadInterval;
     public final Level logLevel;
     public final String serverAddress;
@@ -43,6 +46,7 @@ public final class Config {
     Config(final String applicationName,
            final Duration profilingInterval,
            final EventType profilingEvent,
+           final String profilingAlloc,
            final Duration uploadInterval,
            final Level logLevel,
            final String serverAddress,
@@ -52,6 +56,7 @@ public final class Config {
         this.applicationName = applicationName;
         this.profilingInterval = profilingInterval;
         this.profilingEvent = profilingEvent;
+        this.profilingAlloc = profilingAlloc;
         this.uploadInterval = uploadInterval;
         this.logLevel = logLevel;
         this.serverAddress = serverAddress;
@@ -74,6 +79,7 @@ public final class Config {
             applicationName(),
             profilingInterval(),
             profilingEvent(),
+            profilingAlloc(),
             uploadInterval(),
             logLevel(),
             serverAddress(),
@@ -137,6 +143,14 @@ public final class Config {
                     PYROSCOPE_PROFILER_EVENT_CONFIG, profilingEventStr, DEFAULT_PROFILER_EVENT.id);
             return DEFAULT_PROFILER_EVENT;
         }
+    }
+
+    private static String profilingAlloc() {
+        final String profilingAlloc = System.getenv(PYROSCOPE_PROFILER_ALLOC_CONFIG);
+        if (profilingAlloc == null || profilingAlloc.isEmpty()) {
+            return DEFAULT_PROFILER_ALLOC;
+        }
+        return profilingAlloc.trim().toLowerCase();
     }
 
     private static Duration uploadInterval() {


### PR DESCRIPTION
These events can be sent along with CPU profiling events, which means
initial support for multiple concurrent event support in Java.

The README is also updated with instructions on how to enable multiple
event support.

Related to #3 