### PR TITLE
Mocking j.u.Random with `.withoutAnnotations` option.

### DIFF
--- a/agent/src/test/java/io/pyroscope/javaagent/ExponentialBackoffTest.java
+++ b/agent/src/test/java/io/pyroscope/javaagent/ExponentialBackoffTest.java
@@ -10,12 +10,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 @ExtendWith(MockitoExtension.class)
 public class ExponentialBackoffTest {
     @Test
     void test() {
-        final Random random = mock(Random.class);
+        final Random random = mock(Random.class, withSettings().withoutAnnotations());
         when(random.nextInt(anyInt())).then(invocation -> invocation.getArgument(0));
 
         final ExponentialBackoff exponentialBackoff = new ExponentialBackoff(1_000, 30_000, random);


### PR DESCRIPTION
This patch resolves issue with Java 17 #19
https://stackoverflow.com/questions/70993863/mockito-can-not-mock-random-in-java-17/70994194#70994194