### PR TITLE
feat: add sampling scheduler

### DIFF
--- a/agent/src/main/java/io/pyroscope/javaagent/PyroscopeAgent.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/PyroscopeAgent.java
@@ -101,7 +101,11 @@ public class PyroscopeAgent {
                     if (exporter == null) {
                         exporter = new QueuedExporter(config, new PyroscopeExporter(config, logger), logger);
                     }
-                    scheduler = new ContinuousProfilingScheduler(config, exporter);
+                    if (config.samplingDuration == null) {
+                        scheduler = new ContinuousProfilingScheduler(config, exporter);
+                    } else {
+                        scheduler = new SamplingProfilingScheduler(config, exporter);
+                    }
                 }
                 return new Options(this);
             }

--- a/agent/src/main/java/io/pyroscope/javaagent/impl/SamplingProfilingScheduler.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/impl/SamplingProfilingScheduler.java
@@ -1,0 +1,72 @@
+package io.pyroscope.javaagent.impl;
+
+import static io.pyroscope.javaagent.DateUtils.truncate;
+
+import io.pyroscope.javaagent.Profiler;
+import io.pyroscope.javaagent.Snapshot;
+import io.pyroscope.javaagent.api.Exporter;
+import io.pyroscope.javaagent.api.ProfilingScheduler;
+import io.pyroscope.javaagent.config.Config;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Schedule profiling in sampling mode.
+ * <p>
+ * WARNING: still experimental, may go away or behavior may change
+ */
+public class SamplingProfilingScheduler implements ProfilingScheduler {
+
+    private final Config config;
+    private final Exporter exporter;
+
+    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = Executors.defaultThreadFactory().newThread(r);
+        t.setName("PyroscopeProfilingScheduler_Sampling");
+        t.setDaemon(true);
+        return t;
+    });
+
+    public SamplingProfilingScheduler(Config config, Exporter exporter) {
+        this.config = config;
+        this.exporter = exporter;
+    }
+
+    @Override
+    public void start(Profiler profiler) {
+        final long samplingDurationMillis = config.samplingDuration.toMillis();
+        final Duration uploadInterval = config.uploadInterval;
+        final Runnable dumpProfile = () -> {
+            Instant profilingStartTime = Instant.now();
+            profiler.start();
+            try {
+                Thread.sleep(samplingDurationMillis);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            profiler.stop();
+
+            Snapshot snapshot = profiler.dumpProfile(truncate(profilingStartTime, uploadInterval));
+            exporter.export(snapshot);
+        };
+
+        Duration initialDelay = getInitialDelay();
+        executor.scheduleAtFixedRate(
+            dumpProfile,
+            initialDelay.toMillis(),
+            config.uploadInterval.toMillis(),
+            TimeUnit.MILLISECONDS
+        );
+    }
+
+    private Duration getInitialDelay() {
+        Instant now = Instant.now();
+        Instant prevUploadInterval = truncate(now, config.uploadInterval);
+        Instant nextUploadInterval = prevUploadInterval.plus(config.uploadInterval);
+        Duration initialDelay = Duration.between(now, nextUploadInterval);
+        return initialDelay;
+    }
+}


### PR DESCRIPTION
Full profiling is great but sometimes too large for production applications, sampling may help. For example, profiling at a sampling rate 0.1 means profiling for 1s every 10s. The sampling rate could based on `PYROSCOPE_UPLOAD_INTERVAL`

Supported configs:

- `PYROSCOPE_SAMPLING_DURATION`, specify sampling duration directly, must be less than `PYROSCOPE_UPLOAD_INTERVAL`
- `PYROSCOPE_SAMPLING_RATE`, sampling rate, used to calculate sampling duration, multiplied by `PYROSCOPE_UPLOAD_INTERVAL`. Its value must be in (0, 1) area.

Set one of them should be enough for sampling. If both `PYROSCOPE_SAMPLING_DURATION` and `PYROSCOPE_SAMPLING_RATE` are set, `PYROSCOPE_SAMPLING_RATE` will be ignored.

Not sure this feature is useful or not, need some reviews,

thanks.