### PR TITLE
Adds support for multi-event selection if JFR is enabled

### DIFF
--- a/agent/src/main/java/io/pyroscope/javaagent/EventType.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/EventType.java
@@ -1,6 +1,7 @@
 package io.pyroscope.javaagent;
 
 import java.util.EnumSet;
+import java.util.Arrays;
 import java.util.Optional;
 
 import one.profiler.Events;
@@ -8,25 +9,25 @@ import io.pyroscope.http.Units;
 import io.pyroscope.http.AggregationType;
 
 public enum EventType {
-    CPU (Events.CPU, Units.SAMPLES, AggregationType.SUM),
-    ALLOC (Events.ALLOC, Units.OBJECTS, AggregationType.SUM),
-    LOCK (Events.LOCK, Units.SAMPLES, AggregationType.SUM),
-    WALL (Events.WALL, Units.SAMPLES, AggregationType.SUM),
-    ITIMER (Events.ITIMER, Units.SAMPLES, AggregationType.SUM);
+    CPU(Events.CPU, Units.SAMPLES, AggregationType.SUM),
+    ALLOC(Events.ALLOC, Units.OBJECTS, AggregationType.SUM),
+    LOCK(Events.LOCK, Units.SAMPLES, AggregationType.SUM),
+    WALL(Events.WALL, Units.SAMPLES, AggregationType.SUM),
+    ITIMER(Events.ITIMER, Units.SAMPLES, AggregationType.SUM);
 
     /**
-    * Event type id, as defined in one.profiler.Events.
-    */
+     * Event type id, as defined in one.profiler.Events.
+     */
     public final String id;
 
     /**
-    * Unit option, as expected by Pyroscope's HTTP API.
-    */
+     * Unit option, as expected by Pyroscope's HTTP API.
+     */
     public final Units units;
 
     /**
-    * Aggregation type option, as expected by Pyroscope's HTTP API.
-    */
+     * Aggregation type option, as expected by Pyroscope's HTTP API.
+     */
     public final AggregationType aggregationType;
 
     EventType(String id, Units units, AggregationType aggregationType) {
@@ -36,11 +37,17 @@ public enum EventType {
     }
 
     public static EventType fromId(String id) throws IllegalArgumentException {
-        Optional<EventType> maybeEventType =
-            EnumSet.allOf(EventType.class)
-            .stream()
-            .filter(eventType -> eventType.id.equals(id))
-            .findAny();
+        Optional<EventType> maybeEventType = EnumSet.allOf(EventType.class)
+                .stream()
+                .filter(eventType -> eventType.id.equals(id))
+                .findAny();
         return maybeEventType.orElseThrow(IllegalArgumentException::new);
+    }
+
+    public static EventType fromId(String id, EventType[] eventTypes) throws IllegalArgumentException {
+        Optional<EventType> maybeEventTypes = Arrays.stream(eventTypes)
+                .filter(eventType -> eventType.id.equals(id))
+                .findAny();
+        return maybeEventTypes.orElseThrow(IllegalArgumentException::new);
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/57415489/230995617-251cd543-d8e6-41df-a5a8-cab503704787.png)

Created new builder option: setProfilingEvent**s**

Most notably in Profiler.java, the createJFRCommand ensures that only when the JFR option is enabled will multiple events be used. Otherwise, it'll default to the single Event default set in the Config.

```
private String createJFRCommand() {
        StringBuilder sb = new StringBuilder();

        for (int i = 0; i < eventTypes.length; i++) {
            if (i == 0) {
                sb.append("start,event=").append(eventTypes[0].id);
            } else {
                sb.append(",").append(eventTypes[i].id);
            }

        }
```

Enables end users to utilize the Config Builder to specify multiple event types to mirror the [async-profilers command line options](https://github.com/async-profiler/async-profiler#multiple-events) 

I dig a lot of digging and didn't see any current way in-code for this to work, so if there is and it's simply hidden please let me know.