### PR TITLE
feat: add arbitrary http headers configuration, support basic auth

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -19,8 +19,9 @@ repositories {
 def pyroscopeVersion = project.properties['pyroscope_version']
 dependencies {
     api project(":async-profiler-context")
-    implementation("com.squareup.okhttp3:okhttp:4.9.3")
-    api 'com.google.protobuf:protobuf-java:3.21.1'
+    implementation('com.squareup.okhttp3:okhttp:4.10.0')
+    implementation("com.squareup.moshi:moshi:1.14.0")
+    api 'com.google.protobuf:protobuf-java:3.22.2'
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.7.2'
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.7.2'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.10.0'


### PR DESCRIPTION
- add arbitrary http headers with `PYROSCOPE_HTTP_HEADERS='{"X-Scope-OrgID":"org239"}'`
- add arbitrary http headers from java with `io.pyroscope.javaagent.config.Config.Builder#addHTTPHeader` and `io.pyroscope.javaagent.config.Config.Builder#setHTTPHeaders`
- add basic auth  with url `http://username:pass@localhost:4040`